### PR TITLE
Replaces occurences of "a LED" with "an LED" for consistency.

### DIFF
--- a/Circuit_01/Circuit_01.ino
+++ b/Circuit_01/Circuit_01.ino
@@ -2,7 +2,7 @@
 SparkFun Inventor's Kit
 Example sketch 01
 
-BLINKING A LED
+BLINKING AN LED
 
   Turn an LED on for one second, off for one second,
   and repeat forever.
@@ -84,7 +84,7 @@ void setup()
   // the parenthesis after the function name. The first value is
   // a pin number, the second value is the word INPUT or OUTPUT.
   
-  // Here we'll set up pin 13 (the one connected to a LED) to be
+  // Here we'll set up pin 13 (the one connected to an LED) to be
   // an output. We're doing this because we need to send voltage
   // "out" of the Arduino to the LED.
 

--- a/Circuit_02/Circuit_02.ino
+++ b/Circuit_02/Circuit_02.ino
@@ -110,7 +110,7 @@ int ledPin = 13;      // The LED is connected to digital pin 13
 
 void setup() // this function runs once when the sketch starts up
 {
-  // We'll be using pin 13 to light a LED, so we must configure it
+  // We'll be using pin 13 to light an LED, so we must configure it
   // as an output.
  
   // Because we already created a variable called ledPin, and

--- a/Circuit_03/Circuit_03.ino
+++ b/Circuit_03/Circuit_03.ino
@@ -91,7 +91,7 @@ void loop()
   // LEDs between full-on and full-off.
   
   // The analogWrite() function lets us do this. This function
-  // lets you dim a LED from full-off to full-on over 255 steps.
+  // lets you dim an LED from full-off to full-on over 255 steps.
   
   // We've written a function called showSpectrum() that smoothly
   // steps through all the colors. Again we're just calling it

--- a/Circuit_04/Circuit_04.ino
+++ b/Circuit_04/Circuit_04.ino
@@ -293,7 +293,7 @@ void marquee()
   
   for(index = 0; index <= 3; index++) // Step from 0 to 3
   {
-    digitalWrite(ledPins[index], HIGH);    // Turn a LED on
+    digitalWrite(ledPins[index], HIGH);    // Turn an LED on
     digitalWrite(ledPins[index+4], HIGH);  // Skip four, and turn that LED on
     delay(delayTime);                      // Pause to slow down the sequence
     digitalWrite(ledPins[index], LOW);     // Turn the LED off

--- a/Circuit_06/Circuit_06.ino
+++ b/Circuit_06/Circuit_06.ino
@@ -5,7 +5,7 @@ Example sketch 06
 PHOTO RESISTOR
 
   Use a photoresistor (light sensor) to control the brightness
-  of a LED.
+  of an LED.
 
 Hardware connections:
 

--- a/Circuit_14/Circuit_14.ino
+++ b/Circuit_14/Circuit_14.ino
@@ -314,7 +314,7 @@ void marquee()
   
   for(index = 0; index <= 3; index++)
   {
-    shiftWrite(index, HIGH);    // Turn a LED on
+    shiftWrite(index, HIGH);    // Turn an LED on
     shiftWrite(index+4, HIGH);  // Skip four, and turn that LED on
     delay(delayTime);		// Pause to slow down the sequence
     shiftWrite(index, LOW);	// Turn both LEDs off


### PR DESCRIPTION
Most online dictionaries (Merriam-Webster, Wiktionary, et al.) treat LED as an abbreviation/initialism rather than an acronym, so "an" seems to be the best choice.

References:
- http://www.merriam-webster.com/dictionary/led
- http://en.wiktionary.org/wiki/LED
- http://www.thefreedictionary.com/LED
- http://wiki.answers.com/Q/Is_it_a_LED_or_an_LED&src=ansTT
