### PR TITLE
Update Circuit_07.ino

### DIFF
--- a/Circuit_07/Circuit_07.ino
+++ b/Circuit_07/Circuit_07.ino
@@ -59,7 +59,7 @@ void setup()
   
   // The speed is measured in bits per second, also known as
   // "baud rate". 9600 is a very commonly used baud rate,
-  // and will transfer about 10 characters per second.
+  // and will transfer about 100 characters per second.
   
   Serial.begin(9600);
 }


### PR DESCRIPTION
Fixing baud rate to character conversion.

The serial port is operating 9600 bits per second and the Arduino uses [8-N-1 by default](http://arduino.cc/en/Serial/Begin). So if each single-byte character is 10 bits, by my calculation, it's transferring 96 characters per second. I'm guessing it's just a typo.

I'm enjoying my SIK. Thanks.
