### PR TITLE
Actually using the DISPLAY_TIME to delay the colors.

### DIFF
--- a/Circuit_03/Circuit_03.ino
+++ b/Circuit_03/Circuit_03.ino
@@ -51,7 +51,7 @@ const int BLUE_PIN = 11;
 // This variable controls how fast we loop through the colors.
 // (Try changing this to make the fading faster or slower.)
 
-int DISPLAY_TIME = 100;  // In milliseconds
+int DISPLAY_TIME = 10;  // In milliseconds. Delay for 10 ms (1/100th of a second)
 
 
 void setup()
@@ -247,7 +247,7 @@ void showSpectrum()
 
   {
     showRGB(x);  // Call RGBspectrum() with our new x
-    delay(10);   // Delay for 10 ms (1/100th of a second)
+    delay(DISPLAY_TIME);   
   }
 }
 


### PR DESCRIPTION
The DISPLAY_TIME in circuit #3 is not used, even though it is mentioned in the comments (I guess it should be either deleted or used).

I also made a variation of the sample to use the potentiometer to manage the DELAY_TIME, and also to use a bitwise-based RGB function to improve the way the spectrum if shown. 

You can see it here: https://github.com/josea/SIK-Guide-Code/commit/7fc201848bdd9a4b8cdf6630a9d127b77b423ce1