### PR TITLE
Added missing ln for println

### DIFF
--- a/SIK_circuit06_photoResistor/SIK_circuit06_photoResistor.ino
+++ b/SIK_circuit06_photoResistor/SIK_circuit06_photoResistor.ino
@@ -45,7 +45,7 @@ void loop()
                                                   // the map() function applies a linear scale / offset.
                                                   // map(inputValue, fromMin, fromMax, toMin, toMax);
   Serial.print("\t"); 		  // tab character
-  Serial.print(calibratedlightLevel);   // println prints an CRLF at the end (creates a new line after)
+  Serial.println(calibratedlightLevel);   // println prints an CRLF at the end (creates a new line after)
 
   analogWrite(ledPin, calibratedlightLevel);    // set the led level based on the input lightLevel.
 }


### PR DESCRIPTION
I think this ln of println was missing as the comment implies a println. Without this println, the code outputs a continuous stream of large numbers on the same line to the serial console.